### PR TITLE
Fix #13 advanced-system-console.md

### DIFF
--- a/advanced-system-console.md
+++ b/advanced-system-console.md
@@ -1,75 +1,77 @@
-# PX4 System Console
+# PX4 System Console(系统控制台)
 
-The system console allows low-level access to the system, debug output and analysis of the system boot process. The most convenient way to connect it is by using a [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product), but a plain FTDI cable can be used as well.
+System Console(系统控制台)允许访问系统底层，调试输出和分析系统启动流程。访问System Console最快捷的方式是使用 [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product), 但是常见的FTDI连线也是可以的。
 
 ## System Console vs. Shell
 
-There are multiple shells, but only one console: The system console is the location where all boot output (and applications auto-started on boot) is printed.
 
-  * System console (first shell): Hardware serial port
-  * Additional shells: Pixhawk on USB (e.g. lists as /dev/tty.usbmodem1 on Mac OS)
+有好多种shell，但只有一个Console：系统控制台，它是打印所有引导输出（和引导中自动启动的应用程序）的位置。（可以理解为系统控制台是多个shell中唯一一个打印所有引导输出的shell）
 
-> **Info**
-> USB shell: To just run a few quick commands or test an application connecting to the USB
-> shell is sufficient. The Mavlink shell can be used for this, see below.
-> The hardware serial console is only needed for boot debugging or when USB should be used
-> for MAVLink to connect a [GCS](qgroundcontrol-intro.md).
+The system console is the location where all boot output (and applications auto-started on boot) is printed.
 
-## Snapdragon Flight: Wiring the Console
+  * System console（第一shell）：硬件串口
+  * 其他shell : 连接至USB的Pixhawk(如Mac OS下显示为 /dev/tty.usbmodem1)
 
-The developer kit comes with a breakout board with three pins to access the console. Connect the bundled FTDI cable to the header and the breakout board to the expansion connector.
+> **info**
+> USB shell: 如果只是运行几个简单的命令或测试应用程序，连接到USB shell就足够了。
+>MAVLink shell可以这么使用，参照下文。
+>只有在调试启动流程或USB接口已被用于MAVlink连接地面站[GCS](qgroundcontrol-intro.md)的时候，才需要使用硬件串口console。
 
-## Pixracer / Pixhawk v3: Wiring the Console
+## Snapdragon Flight : Console接线
 
-Connect the 6-pos JST SH 1:1 cable to the Dronecode probe or connect the individual pins of the cable to a FTDI cable like this:
+Snapdragon Flight（骁龙开发平台）开发人员套件里面包含了一个3引脚的接线板，它可以用于访问console。 将附带的FTDI线连接到接头，并将接线板连接到扩展连接器。
 
-| Pixracer / Pixhawk v3  |         | FTDI    |        |
-| -- | -- | -- | -- |
-|1         | +5V (red)     |         | N/C    |
-|2         | UART7 Tx      | 5       | FTDI RX (yellow)  |
-|3         | UART7 Rx      | 4       | FTDI TX (orange)  |
-|4         | SWDIO      |         | N/C   |
-|5         | SWCLK      |         | N/C   |
-|6         | GND     | 1       | FTDI GND (black)   |
+## Pixracer / Pixhawk v3: Console接线
 
-## Pixhawk v1: Wiring the Console
+将6P JST SH 1：1线连接到Dronecode Probe，或者将连接线的每个引脚按照如下所示连接到FTDI线上：
 
-The system console can be accessed through the Dronecode probe or an FTDI cable. Both options are explained in the section below.
+| Pixracer / Pixhawk v3 |           | FTDI |              |
+| --------------------- | --------- | ---- | ------------ |
+| 1                     | +5V (红)  |      | N/C          |
+| 2                     | UART7 Tx  | 5    | FTDI RX (黄) |
+| 3                     | UART7 Rx  | 4    | FTDI TX (橙) |
+| 4                     | SWDIO     |      | N/C          |
+| 5                     | SWCLK     |      | N/C          |
+| 6                     | GND       | 1    | FTDI GND (黑)|
 
-### Connecting via Dronecode Probe
+## Pixhawk v1: Console连线
 
-Connect the 6-pos DF13 1:1 cable on the [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product) to the SERIAL4/5 port of Pixhawk.
+系统console可以通过Dronecode Probe或FTDI线访问。两种方式将在下面介绍。
+
+### 通过Dronecode Probe连接
+
+将 [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product) 的6P DF13 1:1线连接到Pixhawk的SERIAL4/5接口。
 
 ![](images/console/dronecode_probe.jpg)
 
-### Connecting via FTDI 3.3V Cable
+### 通过FTDI 3.3V 线连接
 
-If no Dronecode probe is at hand an FTDI 3.3V (Digi-Key: [768-1015-ND](http://www.digikey.com/product-detail/en/TTL-232R-3V3/768-1015-ND/1836393)) will do as well.
+如果手头没有Dronecode Probe，也可以使用FTDI 3.3V (Digi-Key: [768-1015-ND](http://www.digikey.com/product-detail/en/TTL-232R-3V3/768-1015-ND/1836393)) 。
 
-| Pixhawk 1/2  |         | FTDI    |        |
-| -- | -- | -- | -- |
-|1         | +5V (red)     |         | N/C    |
-|2         | S4 Tx      |         | N/C   |
-|3         | S4 Rx      |         | N/C   |
-|4         | S5 Tx      | 5       | FTDI RX (yellow)   |
-|5         | S5 Rx      | 4       | FTDI TX (orange)   |
-|6         | GND     | 1       | FTDI GND (black)   |
+| Pixhawk 1/2 |           | FTDI |                  |
+| ----------- | --------- | ---- | ---------------- |
+| 1           | +5V (红)  |      | N/C              |
+| 2           | S4 Tx     |      | N/C              |
+| 3           | S4 Rx     |      | N/C              |
+| 4           | S5 Tx     | 5    | FTDI RX (黄)     |
+| 5           | S5 Rx     | 4    | FTDI TX (橙)     |
+| 6           | GND       | 1    | FTDI GND (黑)    |
 
-The connector pinout is shown in the figure below.
+连接器引脚接线如下图所示。
 
 ![](images/console/console_connector.jpg)
 
-The complete wiring is shown below.
+完整的接线如下图所示。
 
 ![](images/console/console_debug.jpg)
 
-## Opening the Console
+## 打开Console
 
-After the console connection is wired up, use the default serial port tool of your choice or the defaults described below:
+Console接线完成后, 使用你选择的默认串口工具或者下面描述的默认工具：
 
 ### Linux / Mac OS: Screen
 
-Install screen on Ubuntu (Mac OS already has it installed):
+Ubuntu下安装screen (Mac OS 已经默认安装了):
 
 <div class="host-code"></div>
 
@@ -77,10 +79,10 @@ Install screen on Ubuntu (Mac OS already has it installed):
 sudo apt-get install screen
 ```
 
-  * Serial: Pixhawk v1 / Pixracer use 57600 baud
-  * Serial: Snapdragon Flight uses 115200 baud
+  * 串口: Pixhawk v1 / Pixracer 使用 57600 波特率
+  * 串行: Snapdragon Flight 使用 115200 波特率
 
-Connect screen at BAUDRATE baud, 8 data bits, 1 stop bit to the right serial port (use `ls /dev/tty*` and watch what changes when unplugging / replugging the USB device). Common names are `/dev/ttyUSB0` and `/dev/ttyACM0` for Linux and `/dev/tty.usbserial-ABCBD` for Mac OS.
+按照 BAUDRATE baud, 8 data bits, 1 stop bit 将screen连接至正确的串口（使用 `ls /dev/tty*`命令，观察在拔下/重插USB设备时什么发生了变化）。Linux下的常见名称是 `/dev/ttyUSB0` 和 `/dev/ttyACM0` ，Mac OS下是`/dev/tty.usbserial-ABCBD`。
 
 <div class="host-code"></div>
 
@@ -90,17 +92,17 @@ screen /dev/ttyXXX BAUDRATE 8N1
 
 ### Windows: PuTTY
 
-Download [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) and start it.
+下载 [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) 并启动它。
 
-Then select 'serial connection' and set the port parameters to:
+选择“串口连接”，然后设置串口参数：
 
   * 57600 baud
   * 8 data bits
   * 1 stop bit
 
-## Getting Started on the Console
+## Console入门
 
-Type `ls` to view the local file system, type `free` to see the remaining free RAM. The console will also display the system boot log when power-cycling the board.
+输入`ls`查看本地文件系统，输入`free`查看剩余可用RAM。当飞控板带电重启时，console也可以显示系统启动日志。
 
 ```bash
 nsh> ls
@@ -108,38 +110,32 @@ nsh> free
 ```
 
 ## MAVLink Shell
-For NuttX-based systems (Pixhawk, Pixracer, ...), the nsh console can also be
-accessed via mavlink. This works via serial link or WiFi (UDP/TCP). Make sure
-that QGC is not running, then start the shell with e.g.
-`./Tools/mavlink_shell.py /dev/ttyACM0` (in the Firmware source). Use `-h` to
-get a description of all available arguments. You may first have to install the
-dependencies with `sudo pip install pymavlink pyserial`.
+对于基于NuttX的系统（Pixhawk，Pixracer，...），也可以通过mavlink访问nsh console。它通过串口连接或WiFi（UDP/TCP）来工作。确保没有运行QGC，然后使用如下命令启动shell`./Tools/mavlink_shell.py /dev/ttyACM0`（在固件源代码中）。使用`-h`获得所有可用参数的描述。也许你先要使用`sudo pip install pymavlink pyserial`安装依赖文件。
 
 # Snapdragon DSP Console
-When you are connected to your Snapdragon board via usb you have access to the px4 shell on the posix side of things.
-The interaction with the DSP side (QuRT) is enabled with the `qshell` posix app and its QuRT companion.
+当通过USB连接到Snapdragon开发板，你可以访问PX4 shell操作posix相关资源 。与DSP侧（QuRT）的交互可以通过`qshell`posix应用程序及其QuRT companion。
 
-With the Snapdragon connected via USB, open the mini-dm to see the output of the DSP:
+将Snapdragon通过USB连接后，打开mini-dm就可以看到DSP的输出：
 ```
 ${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
-Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+注意: 可选方法，尤其是在Mac上,你也可以使用 [nano-dm](https://github.com/kevinmehall/nano-dm)。
 
-Run the main app on the linaro side:
+在linaro侧运行主程序：
 ```
 cd /home/linaro
 ./px4 px4.config
 ```
 
-You can now use all apps loaded on the DSP from the linaro shell with the following syntax:
+你可以通过linaro shell使用DSP加载的所有的应用程序，通过以下语法：
 ```
 pxh> qshell command [args ...]
 ```
 
-For example, to see the available QuRT apps:
+例如，要查看可用QuRT应用程序：
 ```
 pxh> qshell list_tasks
 ```
 
-The output of the executed command is displayed on the minidm.
+所执行命令的输出显示在minidm上。


### PR DESCRIPTION
文中console shell等单词都没有翻译，因为这个就是实际开发中编程相关的，即使翻译了在编程中还是使用的英文，所以索性不翻译。